### PR TITLE
feat(metrics): implement CPU usage metrics endpoint

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,7 +11,9 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.501.0",
         "@aws-sdk/client-ec2": "^3.501.0",
+        "@types/cors": "^2.8.18",
         "@types/express": "^5.0.2",
+        "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "zod": "^3.25.23"
@@ -2337,6 +2339,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.18",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.18.tgz",
+      "integrity": "sha512-nX3d0sxJW41CqQvfOzVG1NCTXfFDrDWIghCZncpHeWlVFd81zxB/DLhg7avFg6eHLCRX7ckBmoIIcqa++upvJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/express": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.2.tgz",
@@ -3132,6 +3143,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/create-jest": {
@@ -5131,6 +5155,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,11 +6,11 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "jest --verbose --no-cache",
-    "test:watch": "jest --watch --verbose --no-cache",
-    "start": "ts-node index.ts",
+    "test": "npx jest --verbose --no-cache",
+    "test:watch": "npx jest --watch --verbose --no-cache",
+    "start": "npx ts-node index.ts",
     "build": "tsc",
-    "dev": "ts-node-dev --respawn src/services/awsService.ts"
+    "dev": "npx ts-node-dev --respawn src/index.ts"
   },
   "keywords": [],
   "author": "",
@@ -28,7 +28,9 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch": "^3.501.0",
     "@aws-sdk/client-ec2": "^3.501.0",
+    "@types/cors": "^2.8.18",
     "@types/express": "^5.0.2",
+    "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "zod": "^3.25.23"

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -12,6 +12,7 @@ const envSchema = z.object({
   INSTANCE_ID: z.string(),
   EC2_IP_ADDRESS: z.string(),
   CI: z.string().default('false'),
+  CORS_ORIGIN: z.string().default('http://localhost:8080'),
 });
 
 type EnvSchema = z.infer<typeof envSchema>;
@@ -67,6 +68,10 @@ export class Config {
 
   public get ec2IpAddress(): string {
     return this.config.EC2_IP_ADDRESS;
+  }
+
+  public get corsOrigin(): string {
+    return this.config.CORS_ORIGIN;
   }
 }
 

--- a/backend/src/controllers/__tests__/metricsController.test.ts
+++ b/backend/src/controllers/__tests__/metricsController.test.ts
@@ -24,10 +24,10 @@ describe('Metrics Controller', () => {
     };
 
     mockReq = {
-      query: {
+      body: {
         ipAddress: '172.31.88.161',
-        periodDays: '1',
-        period: '3600'
+        periodDays: 1,
+        period: 3600
       }
     };
   });
@@ -51,6 +51,21 @@ describe('Metrics Controller', () => {
     expect(mockRes.json).toHaveBeenCalledWith({
       Timestamps: mockMetricData.Timestamps,
       Values: mockMetricData.Values
+    });
+  });
+
+  it('should handle invalid parameter types', async () => {
+    mockReq.body = {
+      ipAddress: '172.31.88.161',
+      periodDays: '1' as any, // Invalid type
+      period: 3600
+    };
+
+    await getCpuUsage(mockReq as Request, mockRes as Response);
+
+    expect(mockRes.status).toHaveBeenCalledWith(400);
+    expect(mockRes.json).toHaveBeenCalledWith({
+      error: 'Invalid parameter types. periodDays and period must be numbers'
     });
   });
 

--- a/backend/src/controllers/metricsController.ts
+++ b/backend/src/controllers/metricsController.ts
@@ -1,37 +1,59 @@
 import { Request, Response } from 'express';
 import { awsService } from '../services/awsService';
-import { MetricsQueryParams } from '../types/metrics';
+
+interface CpuUsageRequest {
+  ipAddress: string;
+  periodDays: number;
+  period: number;
+}
 
 /**
  * Get CPU usage metrics for a specified AWS instance
+ * @param req.body.ipAddress - IP address of the AWS instance
+ * @param req.body.periodDays - Time period in days to fetch data for
+ * @param req.body.period - Interval between samples in seconds
  */
-export const getCpuUsage = async (req: Request, res: Response) => {
+export const getCpuUsage = async (ipAddress: string, periodDays: number, period: number) => {
+  console.log('[MetricsController] Starting CPU usage retrieval:', { ipAddress, periodDays, period });
+  
   try {
-    const { ipAddress, periodDays, period } = req.query as unknown as MetricsQueryParams;
+    if (typeof periodDays !== 'number' || typeof period !== 'number') {
+      console.log('[MetricsController] Invalid parameter types:', { periodDays, period });
+      throw new Error('Invalid parameter types. periodDays and period must be numbers');
+    }
     
+    console.log('[MetricsController] Getting instance ID for IP:', ipAddress);
     const instanceId = await awsService.getInstanceIdForIPAddress(ipAddress);
+    console.log('[MetricsController] Retrieved instance ID');
     
     const endTime = new Date();
     const startTime = new Date(endTime.getTime() - (periodDays * 24 * 60 * 60 * 1000));
+    console.log('[MetricsController] Fetching metrics for time range:', {
+      startTime: startTime.toISOString(),
+      endTime: endTime.toISOString(),
+      period
+    });
     
     const data = await awsService.getMetricDataFromCloudWatch(
       instanceId,
       startTime,
       endTime,
-      Number(period)
+      period
     );
     
-    return res.status(200).json({
+    console.log('[MetricsController] Successfully retrieved metrics data:', {
+      dataPoints: data.Timestamps.length,
+      firstTimestamp: data.Timestamps[0],
+      lastTimestamp: data.Timestamps[data.Timestamps.length - 1]
+    });
+    
+    return {
       Timestamps: data.Timestamps,
       Values: data.Values
-    });
+    };
 
   } catch (error) {
-    console.error('Error retrieving CPU usage:', error);
-    return res.status(500).json({
-      status: 500,
-      message: 'Error retrieving CPU usage',
-      error: error instanceof Error ? error.message : 'Unknown error'
-    });
+    console.error('[MetricsController] Error retrieving CPU usage:', error);
+    throw new Error('Error retrieving CPU usage');
   }
 };

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,0 +1,25 @@
+import express from 'express';
+import cors from 'cors';
+import metricsRoutes from './routes/metricsRoute';
+import { config } from './config/config';
+
+const app = express();
+const PORT = config.port;
+
+app.use(express.json());
+app.use(cors({
+  origin: config.corsOrigin,
+  credentials: true
+}));
+
+app.use('/api/metrics', metricsRoutes);
+
+app.get('/health', (req, res) => {
+  res.status(200).json({ status: 'ok' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+
+export default app;

--- a/backend/src/middleware/validation.ts
+++ b/backend/src/middleware/validation.ts
@@ -15,14 +15,19 @@ export const metricsQuerySchema = z.object({
  * @returns The validated query parameters
  */
 function validateRequestQuery({ query }: { query: any }) {
+    console.log('[Validation] Validating request query:', query);
+    
     const result = metricsQuerySchema.safeParse(query);
     if (!result.success) {
+        console.log('[Validation] Validation failed:', result.error.errors[0].message);
         return { 
             success: false, 
             status: 400, 
             error: result.error.errors[0].message 
         };
     }
+    
+    console.log('[Validation] Validation successful');
     return { success: true, status: 200 };
 }
   

--- a/backend/src/routes/metricsRoute.ts
+++ b/backend/src/routes/metricsRoute.ts
@@ -1,0 +1,46 @@
+import { Router, RequestHandler } from 'express';
+import { getCpuUsage } from '../controllers/metricsController';
+
+const router = Router();
+
+// POST /api/metrics/cpu-usage - Get CPU usage metrics for an AWS instance
+// Request body:
+// {
+//   ipAddress: string,    // IP address of the AWS instance
+//   periodDays: number,   // Time period in days to fetch data for
+//   period: number        // Interval between samples in seconds
+// }
+const cpuUsageHandler: RequestHandler = async (req, res, next) => {
+  console.log('[MetricsRoute] Received CPU usage request:', {
+    ipAddress: req.body.ipAddress,
+    periodDays: req.body.periodDays,
+    period: req.body.period
+  });
+
+  try {
+    const { ipAddress, periodDays, period } = req.body;
+    
+    if (!ipAddress || !periodDays || !period) {
+      console.log('[MetricsRoute] Missing required parameters');
+      res.status(400).json({
+        error: 'Missing required parameters. Please provide ipAddress, periodDays, and period'
+      });
+      return;
+    }
+
+    console.log('[MetricsRoute] Calling getCpuUsage controller');
+    const result = await getCpuUsage(ipAddress, periodDays, period);
+    console.log('[MetricsRoute] Successfully retrieved CPU usage data');
+    res.json(result);
+  } catch (error) {
+    console.error('[MetricsRoute] Error in CPU usage route:', error);
+    res.status(500).json({
+      error: 'Failed to fetch CPU usage data',
+      details: error instanceof Error ? error.message : 'Unknown error'
+    });
+  }
+};
+
+router.post('/cpu-usage', cpuUsageHandler);
+
+export default router; 

--- a/backend/src/services/awsService.ts
+++ b/backend/src/services/awsService.ts
@@ -21,12 +21,14 @@ export class AwsService {
     private ec2Client: EC2Client;
 
     private constructor() {
+        console.log('[AwsService] Initializing AWS service with region:', config.awsRegion);
         this.cloudWatchClient = new CloudWatchClient(awsConfig);
         this.ec2Client = new EC2Client(awsConfig);
     }
 
     public static getInstance(): AwsService {
         if (!AwsService.instance) {
+            console.log('[AwsService] Creating new AWS service instance');
             AwsService.instance = new AwsService();
         }
         return AwsService.instance;
@@ -38,6 +40,8 @@ export class AwsService {
      * @returns The instance ID of the EC2 instance
      */
     async getInstanceIdForIPAddress(ipAddress: string): Promise<string> {
+        console.log('[AwsService] Looking up instance ID for IP:', ipAddress);
+        
         const params = {
             Filters: [
                 {
@@ -48,15 +52,19 @@ export class AwsService {
         };
 
         try {
+            console.log('[AwsService] Sending DescribeInstances request to EC2');
             const data = await this.ec2Client.send(new DescribeInstancesCommand(params));
 
             if (!data.Reservations?.[0]?.Instances?.[0]?.InstanceId) {
+                console.log('[AwsService] No instance found for IP:', ipAddress);
                 throw new Error('No instance found for the given IP address');
             }
+            
             const instanceId = data.Reservations[0].Instances[0].InstanceId;
+            console.log('[AwsService] Found instance ID!');
             return instanceId;
         } catch (error) {
-            console.error(`Error fetching instance ID from IP: ${ipAddress}, error:`, error);
+            console.error('[AwsService] Error fetching instance ID:', error);
             throw error;
         }
     }
@@ -75,6 +83,13 @@ export class AwsService {
         endTime: Date,
         period: number = 1800
     ): Promise<MetricDataResult> {
+        console.log('[AwsService] Fetching CloudWatch metrics:', {
+            instanceId,
+            startTime: startTime.toISOString(),
+            endTime: endTime.toISOString(),
+            period
+        });
+
         const params = {
             StartTime: startTime,
             EndTime: endTime,
@@ -101,21 +116,30 @@ export class AwsService {
         };
 
         try {
+            console.log('[AwsService] Sending GetMetricData request to CloudWatch');
             const data = await this.cloudWatchClient.send(
                 new GetMetricDataCommand(params)
             );
 
             if (!data.MetricDataResults?.[0]) {
+                console.log('[AwsService] No metric data returned from CloudWatch');
                 throw new Error('No metric data returned');
             }
 
-            // convert AWS response to MetricDataResult type
-            return {
+            const result = {
                 Timestamps: data.MetricDataResults[0].Timestamps || [],
                 Values: data.MetricDataResults[0].Values || []
             };
+
+            console.log('[AwsService] Successfully retrieved CloudWatch metrics:', {
+                dataPoints: result.Timestamps.length,
+                firstTimestamp: result.Timestamps[0],
+                lastTimestamp: result.Timestamps[result.Timestamps.length - 1]
+            });
+
+            return result;
         } catch (error) {
-            console.error("Error fetching CloudWatch data:", error);
+            console.error('[AwsService] Error fetching CloudWatch data:', error);
             throw error;
         }
     }


### PR DESCRIPTION
- Added a new endpoint to retrieve CPU usage metrics for AWS instances.
- Introduced CORS support in the Express application with configurable origin.
- Updated configuration to include CORS origin.
- Refactored getCpuUsage function to accept parameters directly from the request body.
- Enhanced error handling for invalid parameter types and missing required parameters.
- Created a dedicated route for CPU usage metrics with appropriate logging for request handling.