### PR TITLE
feat(constants): add TIME_RANGE_OPTIONS and PERIOD_OPTIONS constants

### DIFF
--- a/frontend/src/components/CpuChart.tsx
+++ b/frontend/src/components/CpuChart.tsx
@@ -1,18 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import Chart from 'chart.js/auto';
 import type { ChartConfiguration } from 'chart.js';
-import { MetricDataResult } from '../types/metrics';
-
-/**
- * CpuChartProps interface
- * This interface is used to define the props for the CpuChart component.
- * @param data - The data to display in the chart
- * @param isLoading - Whether the data is still loading
- */
-interface CpuChartProps {
-  data: MetricDataResult | null;
-  isLoading: boolean; 
-}
+import { CpuChartProps } from '../types/metrics';
 
 /**
  * Creates a chart configuration object for CPU usage visualization

--- a/frontend/src/components/ErrorMessage.tsx
+++ b/frontend/src/components/ErrorMessage.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
-
-interface ErrorMessageProps {
-  message: string;
-}
+import { ErrorMessageProps } from '../types/metrics';
 
 const ErrorMessage: React.FC<ErrorMessageProps> = ({ message }) => {
   if (!message) return null;

--- a/frontend/src/components/MetricsForm.tsx
+++ b/frontend/src/components/MetricsForm.tsx
@@ -1,50 +1,6 @@
 import React, { useState } from 'react';
-
-/**
- * MetricsQueryParams interface
- * This interface is used to define the parameters for the metrics query.
- * @param ipAddress - The IP address of the AWS instance
- * @param timeRange - The time range of the metrics
- * @param period - The period of the metrics
- */
-interface MetricsQueryParams {
-  ipAddress: string;
-  timeRange: string;
-  period: number;
-}
-
-/**
- * MetricsFormProps interface
- * This interface is used to define the props for the MetricsForm component.
- * @param onSubmit - The function to call when the form is submitted
- * @param isLoading - Whether the form is loading
- */
-interface MetricsFormProps {
-  onSubmit: (params: MetricsQueryParams) => void;
-  isLoading: boolean;
-}
-
-const TIME_RANGE_OPTIONS = [
-  'Last Hour',
-  'Last 6 Hours',
-  'Last 12 Hours',
-  'Last Day',
-  'Last 7 Days',
-];
-
-const PERIOD_OPTIONS = [
-  60,      // 1 minute
-  300,     // 5 minutes
-  600,     // 10 minutes
-  900,     // 15 minutes
-  1800,    // 30 minutes
-  3600,    // 1 hour
-  7200,    // 2 hours
-  14400,   // 4 hours
-  28800,   // 8 hours
-  43200,   // 12 hours
-  86400    // 24 hours
-];
+import { MetricsFormProps, MetricsQueryParams } from '../types/metrics';
+import { TIME_RANGE_OPTIONS, PERIOD_OPTIONS } from '../constants';
 
 const MetricsForm: React.FC<MetricsFormProps> = ({ onSubmit, isLoading }) => {
   const [formData, setFormData] = useState<MetricsQueryParams>({

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,0 +1,29 @@
+/**
+ * TIME_RANGE_OPTIONS constant
+ * This constant is used to define the time range options for the metrics form.
+ */
+export const TIME_RANGE_OPTIONS = [
+    'Last Hour',
+    'Last 6 Hours',
+    'Last 12 Hours',
+    'Last Day',
+    'Last 7 Days',
+  ];
+  
+  /**
+   * PERIOD_OPTIONS constant
+   * This constant is used to define the period options for the metrics form.
+   */
+  export const PERIOD_OPTIONS = [
+    60,      // 1 minute
+    300,     // 5 minutes
+    600,     // 10 minutes
+    900,     // 15 minutes
+    1800,    // 30 minutes
+    3600,    // 1 hour
+    7200,    // 2 hours
+    14400,   // 4 hours
+    28800,   // 8 hours
+    43200,   // 12 hours
+    86400    // 24 hours
+  ];

--- a/frontend/src/types/metrics.ts
+++ b/frontend/src/types/metrics.ts
@@ -19,4 +19,44 @@ export interface ErrorResponse {
   status: number;
   message: string;
   error?: string;
-} 
+}
+
+
+/**
+ * CpuChartProps interface
+ * This interface is used to define the props for the CpuChart component.
+ * @param data - The data to display in the chart
+ * @param isLoading - Whether the data is still loading
+ */
+export interface CpuChartProps {
+  data: MetricDataResult | null;
+  isLoading: boolean; 
+}
+
+export interface ErrorMessageProps {
+  message: string;
+}
+
+/**
+ * MetricsQueryParams interface
+ * This interface is used to define the parameters for the metrics query.
+ * @param ipAddress - The IP address of the AWS instance
+ * @param timeRange - The time range of the metrics
+ * @param period - The period of the metrics
+ */
+export interface MetricsQueryParams {
+  ipAddress: string;
+  timeRange: string;
+  period: number;
+}
+
+/**
+ * MetricsFormProps interface
+ * This interface is used to define the props for the MetricsForm component.
+ * @param onSubmit - The function to call when the form is submitted
+ * @param isLoading - Whether the form is loading
+ */
+export interface MetricsFormProps {
+  onSubmit: (params: MetricsQueryParams) => void;
+  isLoading: boolean;
+}


### PR DESCRIPTION
- Introduced TIME_RANGE_OPTIONS and PERIOD_OPTIONS constants to centralize time range and period selections for the metrics form.
- Updated CpuChart and MetricsForm components to utilize these constants, improving code organization and maintainability.
- Added relevant JSDoc comments for better documentation of the new constants.